### PR TITLE
add explicit ClassLoader to javafx IkonResolver

### DIFF
--- a/subprojects/ikonli-javafx/src/main/java/org/kordamp/ikonli/javafx/IkonResolver.java
+++ b/subprojects/ikonli-javafx/src/main/java/org/kordamp/ikonli/javafx/IkonResolver.java
@@ -34,7 +34,9 @@ public class IkonResolver {
     static {
         INSTANCE = new IkonResolver();
 
-        ServiceLoader<IkonHandler> loader = ServiceLoader.load(IkonHandler.class);
+        ServiceLoader<IkonHandler> loader = 
+ServiceLoader.load(IkonHandler.class, 
+IkonResolver.class.getClassLoader());
         for (IkonHandler handler : loader) {
             HANDLERS.add(handler);
             handler.setFont(Font.loadFont(IkonResolver.class.getClassLoader().getResource(handler.getFontResourcePath()).toExternalForm(), 16));


### PR DESCRIPTION
This change allows the usage of javafx Ikonli Elements in
Gluon-Scenebuilder.