### PR TITLE
Correctly center icon vertically

### DIFF
--- a/subprojects/ikonli-swing/src/main/java/org/kordamp/ikonli/swing/FontIcon.java
+++ b/subprojects/ikonli-swing/src/main/java/org/kordamp/ikonli/swing/FontIcon.java
@@ -58,7 +58,7 @@ public class FontIcon implements Icon {
                 g2.setFont(font);
                 g2.setColor(iconColor);
 
-                int sy = iconSize - (iconSize / 4) + (iconSize / 16);
+                int sy = g2.getFontMetrics().getAscent();
                 g2.drawString(String.valueOf(ikon.getCode()), 0, sy);
 
                 g2.dispose();


### PR DESCRIPTION
The font metrics ascent is used to center the font vertically.