### PR TITLE
fix resolveSize

### DIFF
--- a/subprojects/ikonli-javafx/src/main/java9/org/kordamp/ikonli/javafx/FontIcon.java
+++ b/subprojects/ikonli-javafx/src/main/java9/org/kordamp/ikonli/javafx/FontIcon.java
@@ -332,8 +332,6 @@ public class FontIcon extends Text implements Icon {
             } catch (NumberFormatException e) {
                 throw invalidDescription(iconCode, e);
             }
-        } else {
-            setIconSize(16);
         }
     }
 


### PR DESCRIPTION
Hi, I fixed the resolveFunction to not override the icon size. No need to specify the size to use by default if the size is not defined in the literal because the constructor already define the size by default to 16.

#21 